### PR TITLE
Add missing templates to Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ __marimo__/
 # Local secrets
 *password*
 *secret*
+# But allow Helm secrets
+!secrets.yaml
+!externalsecret.yaml

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for CLICC Devices application
 name: clicc-devices
-version: 1.0.0
+version: 1.0.1

--- a/charts/templates/externalsecret.yaml
+++ b/charts/templates/externalsecret.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "clicc-devices.fullname" . }}-externalsecret
+  namespace: clicc-devices{{ .Values.django.env.run_env }}
+  {{- with .Values.django.externalSecrets.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  refreshInterval: 10m
+  secretStoreRef:
+    name: systems-clustersecretstore
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "clicc-devices.fullname" . }}-secrets
+  data:
+    - secretKey: "ALMA_API_KEY"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.alma_api_key }}
+    - secretKey: "DJANGO_SECRET_KEY"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.django_secret_key }}
+    - secretKey: "DJANGO_DB_PASSWORD"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.db_password }}

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -1,0 +1,14 @@
+{{ if not .Values.django.externalSecrets.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "clicc-devices.fullname" . }}-secrets
+  namespace: clicc-devices{{ .Values.django.env.run_env }}
+  labels:
+{{ include "clicc-devices.fullname" . | indent 4 }}
+type: Opaque
+data:
+  ALMA_API_KEY: {{ .Values.django.env.alma_api_key | b64enc | quote }}
+  DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}
+  DJANGO_DB_PASSWORD: {{ .Values.django.env.db_password | b64enc | quote }}
+{{ end }}


### PR DESCRIPTION
Fixes problem caused by incorrect `.gitignore` excluding "secrets" templates from repository.
