### PR TITLE
SYS-2015: apply security updates

### DIFF
--- a/charts/prod-cliccdevices-values.yaml
+++ b/charts/prod-cliccdevices-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/clicc-devices
-  tag: v1.0.2
+  tag: v1.0.3
   pullPolicy: Always
 
 nameOverride: ""

--- a/clicc_devices/templates/release_notes.html
+++ b/clicc_devices/templates/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.3</h4>
+<p><i>September 18, 2025</i></p>
+<ul>
+    <li>Upgrade Django to 5.2.6.</li>
+</ul>
+
 <h4>1.0.2</h4>
 <p><i>September 3, 2025</i></p>
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Standard packages used by all of our Django applications.
-Django==5.2.2
+Django==5.2.6
 django-bootstrap5==25.1
 psycopg==3.2.9
 gunicorn==23.0.0


### PR DESCRIPTION
Implements [SYS-2015](https://uclalibrary.atlassian.net/browse/SYS-2015)

Upgrades Django to 5.2.6, addressing all current [dependabot alerts](https://github.com/UCLALibrary/clicc-devices/security/dependabot) for this repo.

Also includes release notes and tag bump for deployment.