### PR TITLE
SYS-2030: use updated Alma API package

### DIFF
--- a/charts/prod-cliccdevices-values.yaml
+++ b/charts/prod-cliccdevices-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/clicc-devices
-  tag: v1.0.3
+  tag: v1.0.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/clicc_devices/management/commands/retrieve_sets.py
+++ b/clicc_devices/management/commands/retrieve_sets.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
                 alma_set = alma_client.get_set(set_obj.alma_set_id)
             except APIError as e:
                 logger.error(
-                    f"Failed to retrieve Alma set with Alma ID {set_obj.alma_set_id}: ",
+                    f"Failed to retrieve Alma set with Alma ID {set_obj.alma_set_id}: "
                     f"{e.error_messages}",
                 )
                 continue

--- a/clicc_devices/management/commands/retrieve_sets.py
+++ b/clicc_devices/management/commands/retrieve_sets.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from clicc_devices.models import Set, Item
 import logging
 import argparse
-from alma_api_client import AlmaAPIClient
+from alma_api_client import AlmaAPIClient, APIError
 
 
 class Command(BaseCommand):
@@ -55,11 +55,12 @@ class Command(BaseCommand):
             )
 
             # Retrieve set from Alma
-            alma_set = alma_client.get_set(set_obj.alma_set_id)
-
-            if not alma_set:
+            try:
+                alma_set = alma_client.get_set(set_obj.alma_set_id)
+            except APIError as e:
                 logger.error(
-                    f"Failed to retrieve Alma set with Alma ID {set_obj.alma_set_id}."
+                    f"Failed to retrieve Alma set with Alma ID {set_obj.alma_set_id}: ",
+                    f"{e.error_messages}",
                 )
                 continue
 
@@ -84,3 +85,4 @@ class Command(BaseCommand):
                 f"(Alma ID: {set_obj.alma_set_id}). "
                 f"Items retrieved: {num_items}."
             )
+        logger.info("Set retrieval process completed.")

--- a/clicc_devices/templates/release_notes.html
+++ b/clicc_devices/templates/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.4</h4>
+<p><i>October 2, 2025</i></p>
+<ul>
+    <li>Update data retrieval command to use version 0.2.0 of Alma API Client package.</li>
+</ul>
+
 <h4>1.0.3</h4>
 <p><i>September 18, 2025</i></p>
 <ul>


### PR DESCRIPTION
Implements [SYS-2030](https://uclalibrary.atlassian.net/browse/SYS-2030)

Updates the CLICC Devices application to use the latest version (0.2.0) of the Alma API Client package.

The only place where Alma data is retrieved is in the `retrieve_sets.py` management command. I made a small change to use the new `APIError` class (and added an additional log message at the end of the process). No logical changes were needed.

To test, rebuild the container to get the latest version of the API client, and run the management command: `python manage.py retrieve_sets`. Tests should also still pass (though we didn't have any for this command specifically): `python manage.py test`

Also includes release notes and tag bump for deployment.


[SYS-2030]: https://uclalibrary.atlassian.net/browse/SYS-2030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ