### PR TITLE
SYS-2127: Update Django to 5.2.10 to patch security issues

### DIFF
--- a/charts/prod-cliccdevices-values.yaml
+++ b/charts/prod-cliccdevices-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/clicc-devices
-  tag: v1.0.4
+  tag: v1.0.5
   pullPolicy: Always
 
 nameOverride: ""

--- a/clicc_devices/templates/release_notes.html
+++ b/clicc_devices/templates/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.5</h4>
+<p><i>January 6, 2026</i></p>
+<ul>
+    <li>Update Django to 5.2.10 to patch security issues.</li>
+</ul>
+
 <h4>1.0.4</h4>
 <p><i>October 2, 2025</i></p>
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Standard packages used by all of our Django applications.
-Django==5.2.6
+Django==5.2.10
 django-bootstrap5==25.1
 psycopg==3.2.9
 gunicorn==23.0.0


### PR DESCRIPTION
Implements [SYS-2127](https://uclalibrary.atlassian.net/browse/SYS-2127)

Updates Django to 5.2.10 to patch security issues and resolve Dependabot alerts.

All 5 tests still pass after updating Django.

You might need to use the `--no-cache` option when re-building the `django` container (at least, I did): `docker compose build --no-cache`

[SYS-2127]: https://uclalibrary.atlassian.net/browse/SYS-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ