### PR TITLE
Dlsr 409/allow cors for api

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,34 @@
 {
-	"name": "Django",
-	"dockerComposeFile": "../docker-compose.yml",
-	"service": "django",
-	"workspaceFolder": "/home/django/django_app",
-	"customizations": {
-			"vscode": {
-					"extensions": [
-							"ms-python.python",
-							"ms-python.black-formatter",
-							"ms-python.flake8"
-					],
-					"settings": {
-							"editor.formatOnSave": true,
-							"python.analysis.typeCheckingMode": "standard",
-							"python.analysis.diagnosticSeverityOverrides": {
-								// Downgrade errors for Django's dynamic "id" model attributes
-								"reportAttributeAccessIssue": "information",
-								// Downgrade errors when accessing methods on Django's 
-								// related model attributes, like obj.assigned_user.get_full_name()
-								"reportOptionalMemberAccess": "information"
-							},
-							"python.editor.defaultFormatter": "ms-python.black-formatter",
-					"flake8.args": [
-									"--max-line-length=100",
-									"--extend-ignore=E203"
-							]
-					}
-			}
-	}
+  "name": "Django",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "django",
+  "workspaceFolder": "/home/django/django_app",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python@2026.4.0",
+        "ms-python.vscode-pylance@2026.2.1",
+        "ms-python.black-formatter@2026.6.0",
+        "ms-python.flake8@2026.6.0"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "python.analysis.typeCheckingMode": "standard",
+        "python.analysis.diagnosticSeverityOverrides": {
+          // Downgrade errors for Django's dynamic "id" model attributes
+          "reportAttributeAccessIssue": "information",
+          // Downgrade errors when accessing methods on Django's
+          // related model attributes, like obj.assigned_user.get_full_name()
+          "reportOptionalMemberAccess": "information"
+        },
+        "python.editor.defaultFormatter": "ms-python.black-formatter",
+        "extensions.autoUpdate": false,
+        "extensions.autoCheckUpdates": true,
+        "flake8.args": [
+          "--max-line-length=100",
+          "--extend-ignore=E203"
+        ]
+      }
+    }
+  }
 }

--- a/charts/prod-cliccdevices-values.yaml
+++ b/charts/prod-cliccdevices-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/clicc-devices
-  tag: v1.0.5
+  tag: v1.0.6
   pullPolicy: Always
 
 nameOverride: ""

--- a/clicc_devices/templates/release_notes.html
+++ b/clicc_devices/templates/release_notes.html
@@ -4,6 +4,13 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.6</h4>
+<p><i>June 23, 2026</i></p>
+<ul>
+    <li>Add CORS support so API can be consumed by our main website.</li>
+    <li>Update Django to 5.2.14 to patch security issues.</li>
+</ul>
+
 <h4>1.0.5</h4>
 <p><i>January 6, 2026</i></p>
 <ul>

--- a/clicc_devices/tests.py
+++ b/clicc_devices/tests.py
@@ -98,3 +98,36 @@ class DeviceViewTests(TestCase):
         self.assertIn("typeB", unit1_data)
         self.assertEqual(unit1_data["typeA"], 8)  # 3 from set1 + 5 from set3
         self.assertEqual(unit1_data["typeB"], 4)
+
+
+class CORSHeadersTests(TestCase):
+    def test_valid_prod_origin(self):
+        # Add production website origin header to request
+        prod_origin = "https://library.ucla.edu"
+        request_headers = {"Origin": prod_origin}
+        response = self.client.get("/devices/", headers=request_headers)
+        expected_header = "access-control-allow-origin"
+        expected_header_value = prod_origin
+        self.assertIn(expected_header, response.headers)
+        self.assertEqual(expected_header_value, response.headers.get(expected_header))
+
+    def test_valid_test_origin(self):
+        # Add test website origin header to request.
+        # These vary, so this tests the regex in settings.CORS_ALLOWED_ORIGIN_REGEXES
+        test_origin = "https://deploy-preview-931--uclalibrary-test.netlify.app"
+        request_headers = {"Origin": test_origin}
+        response = self.client.get("/devices/", headers=request_headers)
+        expected_header = "access-control-allow-origin"
+        expected_header_value = test_origin
+        self.assertIn(expected_header, response.headers)
+        self.assertEqual(expected_header_value, response.headers.get(expected_header))
+
+    def test_invalid_origin(self):
+        # Add an unsupported (not allowed) origin header to request.
+        invalid_origin = "https://my.evilhacker.site"
+        request_headers = {"Origin": invalid_origin}
+        response = self.client.get("/devices/", headers=request_headers)
+        # In this case, the access control header should not be present,
+        # since the Origin header is not in our allowed values.
+        unexpected_header = "access-control-allow-origin"
+        self.assertNotIn(unexpected_header, response.headers)

--- a/project/settings.py
+++ b/project/settings.py
@@ -52,10 +52,13 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_bootstrap5",
+    "corsheaders",
     "clicc_devices",
 ]
 
 MIDDLEWARE = [
+    # corsheaders should be as early as possible in this list
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     # Enable whitenoise in production too
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -186,3 +189,14 @@ LOGGING = {
 
 # Alma API credentials
 ALMA_API_KEY = os.getenv("ALMA_API_KEY")
+
+# CORS headers configuration, to allow our API responses
+# to be used by our own websites.
+# Production: just one domain
+CORS_ALLOWED_ORIGINS = [
+    "https://library.ucla.edu",
+]
+# Test/CI: Wildcards needed for Netlify
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^https://deploy-preview-\d+--uclalibrary-test\.netlify\.app$",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
 # Standard packages used by all of our Django applications.
-Django==5.2.10
+Django==5.2.14
 django-bootstrap5==25.1
 psycopg==3.2.9
 gunicorn==23.0.0
 whitenoise==6.9.0
 
 # Add optional packages below.
-# django-simple-history==3.8.0 
+# Support CORS headers for API requests
+django-cors-headers==4.9.0
 # Install the Alma API client from GitHub.
 git+https://github.com/UCLALibrary/alma-api-client


### PR DESCRIPTION
Implements [DLSR-409](https://uclalibrary.atlassian.net/browse/DLSR-409).  Version updated to `1.0.6` for deployment.

This PR adds support for Cross-Origin Resource Sharing (CORS) headers, configured to allow our main website to request data from our API.  Without CORS, browsers don't allow content from one domain (or "origin") to be accessed when processing pages which came from a different domain.

I added the [django-cors-headers](https://pypi.org/project/django-cors-headers/) package, installed it via `settings.py`, and configured it to allow requests from our production website domain and from the corresponding test/CI domains.  These are dynamic, so a regex is needed.

I added 3 tests, covering our static production domain, dynamic test/CI domains, and an invalid domain (one not allowed to make requests).  `docker compose exec django python manage.py test` now shows 8 tests, all passing.

You can also test manually via `curl` - not needed, but useful for understanding this corner of CORS a little better:
```
# Set the Origin header for this request to a valid test/CI domain.
# --verbose flag shows both request and response headers.

$ curl -H "Origin: https://deploy-preview-931--uclalibrary-test.netlify.app" --verbose http://127.0.0.1:8000/devices/
*   Trying 127.0.0.1:8000...
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> GET /devices/ HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/7.88.1
> Accept: */*
> Origin: https://deploy-preview-931--uclalibrary-test.netlify.app
>
< HTTP/1.1 200 OK
< Date: Tue, 23 Jun 2026 21:12:05 GMT
< Server: WSGIServer/0.2 CPython/3.13.5
< Content-Type: application/json
< X-Frame-Options: DENY
< Content-Length: 112
< X-Content-Type-Options: nosniff
< Referrer-Policy: same-origin
< Cross-Origin-Opener-Policy: same-origin
< Vary: origin
< access-control-allow-origin: https://deploy-preview-931--uclalibrary-test.netlify.app
<
* Connection #0 to host 127.0.0.1 left intact
{"Powell": {"Chromebook": 43, "iPad": 83, "Macbook": 106}, "YRL": {"Chromebook": 67, "iPad": 84, "Macbook": 93}}
```

The response headers now include a `access-control-allow-origin` header, with the same value as the requesting `Origin` header. (HTTP headers are case-insensitive, and the `django-cors-headers` package chose to use all-lower-case for header names.)

Compare with a request from an invalid origin:
```
$ curl -H "Origin: https://my.evil.site" --verbose http://127.0.0.1:8000/devices/
*   Trying 127.0.0.1:8000...
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> GET /devices/ HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/7.88.1
> Accept: */*
> Origin: https://my.evil.site
>
< HTTP/1.1 200 OK
< Date: Tue, 23 Jun 2026 21:16:18 GMT
< Server: WSGIServer/0.2 CPython/3.13.5
< Content-Type: application/json
< X-Frame-Options: DENY
< Content-Length: 112
< X-Content-Type-Options: nosniff
< Referrer-Policy: same-origin
< Cross-Origin-Opener-Policy: same-origin
< Vary: origin
<
* Connection #0 to host 127.0.0.1 left intact
{"Powell": {"Chromebook": 43, "iPad": 83, "Macbook": 106}, "YRL": {"Chromebook": 67, "iPad": 84, "Macbook": 93}}
```

The same response, except no `access-control-allow-origin` header is included because the `Origin` header is not an allowed one.

Note that this response to an "invalid" origin **still contains the response JSON data**.  My understanding, which is definitely incomplete, is that it's up to us to enforce that.  For our very simple use case, I'm fine with any site requesting and using this generic data.  Per the module documentation, the "Signals" section says
> you can attach code to check if a given request should be allowed

We could also configure this to just send CORS headers when the specific `/devices/` API URL is requested, etc.  I chose not to do any of that.  I don't even know if this really works correctly for our own use case, until this is deployed....





[DLSR-409]: https://uclalibrary.atlassian.net/browse/DLSR-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ