### PR TITLE
DLSR-409: Add alternate production domain for main website

### DIFF
--- a/charts/prod-cliccdevices-values.yaml
+++ b/charts/prod-cliccdevices-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/clicc-devices
-  tag: v1.0.6
+  tag: v1.0.7
   pullPolicy: Always
 
 nameOverride: ""

--- a/clicc_devices/templates/release_notes.html
+++ b/clicc_devices/templates/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.7</h4>
+<p><i>June 29, 2026</i></p>
+<ul>
+    <li>Add CORS support for alternate production main website domain.</li>
+</ul>
+
 <h4>1.0.6</h4>
 <p><i>June 23, 2026</i></p>
 <ul>

--- a/clicc_devices/tests.py
+++ b/clicc_devices/tests.py
@@ -103,7 +103,7 @@ class DeviceViewTests(TestCase):
 class CORSHeadersTests(TestCase):
     def test_valid_prod_origin(self):
         # Add production website origin header to request
-        prod_origin = "https://library.ucla.edu"
+        prod_origin = "https://www.library.ucla.edu"
         request_headers = {"Origin": prod_origin}
         response = self.client.get("/devices/", headers=request_headers)
         expected_header = "access-control-allow-origin"

--- a/project/settings.py
+++ b/project/settings.py
@@ -192,8 +192,9 @@ ALMA_API_KEY = os.getenv("ALMA_API_KEY")
 
 # CORS headers configuration, to allow our API responses
 # to be used by our own websites.
-# Production: just one domain
+# Production: explicit domains, though library redirects to www.library.
 CORS_ALLOWED_ORIGINS = [
+    "https://www.library.ucla.edu",
     "https://library.ucla.edu",
 ]
 # Test/CI: Wildcards needed for Netlify


### PR DESCRIPTION
Fixes a problem with CORS support, adding `www.library.ucla.edu` explicitly with `library.ucla.edu`.  Version bumped to `1.0.7` for deployment.